### PR TITLE
[Auto-sync] Homepage API Documentation (#2490)

### DIFF
--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -91,7 +91,7 @@ const sidebars = {
           label: 'Preview',
           id: 'cms/features/preview',
           customProps: {
-            new: true,
+            new: false,
           }
         },
         {
@@ -181,7 +181,7 @@ const sidebars = {
           label: 'Strapi Client',
           id: 'cms/api/client',
           customProps: {
-            new: true,
+            new: false,
           }
         },
         'cms/api/graphql',
@@ -290,6 +290,9 @@ const sidebars = {
           collapsed: true,
           collapsible: true,
           label: "Database",
+          customProps: {
+            updated: false,
+          },
           items: [
             {
               type: 'doc',
@@ -399,7 +402,7 @@ const sidebars = {
           label: 'Homepage customization',
           id: 'cms/admin-panel-customization/homepage',
           customProps: {
-            new: true,
+            new: false,
           }
         },
         // 'cms/cli', // TODO moved to its own category, add TOC component here to highlight it


### PR DESCRIPTION
Recreating pull request #2490 from strapi/documentation.

## Summary
This PR adds documentation for the new Homepage customization feature in Strapi 5.13+ that allows creating custom widgets for the admin panel homepage.

## Changes
- ✅ Add/Update homepage customization documentation  
- ✅ Update sidebar navigation to include homepage docs
- ✅ Update feature flag badge documentation

## Files Modified
1. `docusaurus/docs/cms/admin-panel-customization/homepage.md` - Homepage customization docs
2. `docusaurus/sidebars.js` - Added navigation entry
3. `docusaurus/docs/cms/configurations/features.md` - Updated feature flag description

**Source**: Copied exactly from https://github.com/strapi/documentation/pull/2490

## Commits
1. Update homepage customization documentation
2. Update sidebar with homepage customization
3. Update feature flag documentation
